### PR TITLE
feat: Update AnyURLSession to main branch

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
         "package": "swift-anyurlsession",
         "repositoryURL": "https://github.com/thebrowsercompany/AnyURLSession",
         "state": {
-          "branch": "9b8e39b",
-          "revision": "9b8e39b95f8290909b976619eb00dc8c9ba472bf",
+          "branch": "main",
+          "revision": "bb5bf3bbee5a98ea6c38b89c66a04812f904f958",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "LDSwiftEventSource", targets: ["LDSwiftEventSource"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/thebrowsercompany/AnyURLSession", revision: "9b8e39b")
+        .package(url: "https://github.com/thebrowsercompany/AnyURLSession", branch: "main")
     ],
     targets: [
         .target(


### PR DESCRIPTION
This just points the Package to the `main` branch of the AnyURLSession repo instead of a specific SHA.