### PR TITLE
Remove verbose logs

### DIFF
--- a/Source/LDSwiftEventSource.swift
+++ b/Source/LDSwiftEventSource.swift
@@ -161,11 +161,7 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
 
     private let config: EventSource.Config
 
-    private var readyState: ReadyState = .raw {
-        didSet {
-            logger.log(.debug, "State: %@ -> %@", oldValue.rawValue, readyState.rawValue)
-        }
-    }
+    private var readyState: ReadyState = .raw
 
     private let utf8LineParser: UTF8LineParser = UTF8LineParser()
     private let eventParser: EventParser
@@ -234,7 +230,6 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
     }
 
     private func connect() {
-        logger.log(.info, "Starting EventSource client")
         let task = urlSession?.dataTask(with: createRequest())
         task?.resume()
         sessionTask = task
@@ -293,8 +288,6 @@ class EventSourceDelegate: NSObject, URLSessionDataDelegate {
                            dataTask: URLSessionDataTask,
                            didReceive response: URLResponse,
                            completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
-        logger.log(.debug, "Initial reply received")
-
         guard readyState != .shutdown
         else {
             completionHandler(.cancel)


### PR DESCRIPTION
Just removes the very verbose logs for normal state changes.

These logs are so annoying, so I figured since we already have a fork we might as well remove them.

![CleanShot 2024-10-28 at 11 40 37](https://github.com/user-attachments/assets/38c1663a-248d-4862-ba59-99cdee3cbcaa)
